### PR TITLE
feat: add scene flow state machine architecture

### DIFF
--- a/Assets/Ludo/Scenes/Runtime/Flow/FlowState.cs
+++ b/Assets/Ludo/Scenes/Runtime/Flow/FlowState.cs
@@ -1,0 +1,53 @@
+using UnityEngine;
+
+namespace Ludo.Scenes.Flow
+{
+    /// <summary>
+    /// Base class for scene flow states.
+    /// States encapsulate a single deterministic mode of the user experience.
+    /// </summary>
+    /// <typeparam name="TEvent">Type of events driving transitions.</typeparam>
+    public abstract class FlowState<TEvent> where TEvent : struct
+    {
+        /// <summary>
+        /// Reference to the owning scene controller.
+        /// </summary>
+        protected readonly SceneFlowController<TEvent> Controller;
+
+        protected FlowState(SceneFlowController<TEvent> controller)
+        {
+            Controller = controller;
+        }
+
+        /// <summary>
+        /// Called when the state becomes active.
+        /// </summary>
+        public virtual Awaitable Enter() => default;
+
+        /// <summary>
+        /// Called every frame while this state is active.
+        /// </summary>
+        public virtual void Tick() { }
+
+        /// <summary>
+        /// Called when the state is about to be deactivated.
+        /// </summary>
+        public virtual Awaitable Exit() => default;
+
+        /// <summary>
+        /// Attempts to handle an incoming event. Returns the next state if a transition is required,
+        /// otherwise <c>null</c> to remain in the current state.
+        /// </summary>
+        public virtual FlowState<TEvent>? Handle(TEvent evt) => null;
+
+        /// <summary>
+        /// Creates a nested state machine to model modal or sub flows.
+        /// Derived states are responsible for managing the returned machine's lifecycle.
+        /// </summary>
+        protected StateMachine<TNestedEvent> CreateNestedStateMachine<TNestedEvent>() where TNestedEvent : struct
+        {
+            return new StateMachine<TNestedEvent>();
+        }
+    }
+}
+

--- a/Assets/Ludo/Scenes/Runtime/Flow/SceneFlowController.cs
+++ b/Assets/Ludo/Scenes/Runtime/Flow/SceneFlowController.cs
@@ -1,0 +1,48 @@
+using UnityEngine;
+
+namespace Ludo.Scenes.Flow
+{
+    /// <summary>
+    /// Base component for scene flow controllers.
+    /// Each scene should implement a concrete controller to orchestrate its flow.
+    /// </summary>
+    /// <typeparam name="TEvent">Type of events driving state transitions.</typeparam>
+    [DisallowMultipleComponent]
+    public abstract class SceneFlowController<TEvent> : MonoBehaviour where TEvent : struct
+    {
+        readonly StateMachine<TEvent> _stateMachine = new StateMachine<TEvent>();
+
+        /// <summary>
+        /// Access to the underlying state machine, allowing nested flows to dispatch events.
+        /// </summary>
+        protected StateMachine<TEvent> Machine => _stateMachine;
+
+        /// <summary>
+        /// Creates the initial state for this scene.
+        /// </summary>
+        protected abstract FlowState<TEvent> CreateInitialState();
+
+        /// <summary>
+        /// Dispatches an event into the scene flow.
+        /// </summary>
+        public Awaitable Dispatch(TEvent evt) => _stateMachine.Dispatch(evt);
+
+        /// <summary>
+        /// Unity callback. Initializes the state machine when the scene starts.
+        /// </summary>
+        protected async void Start()
+        {
+            var initial = CreateInitialState();
+            await _stateMachine.SetInitialState(initial);
+        }
+
+        /// <summary>
+        /// Unity callback executed every frame.
+        /// </summary>
+        protected virtual void Update()
+        {
+            _stateMachine.Tick();
+        }
+    }
+}
+

--- a/Assets/Ludo/Scenes/Runtime/Flow/StateMachine.cs
+++ b/Assets/Ludo/Scenes/Runtime/Flow/StateMachine.cs
@@ -1,0 +1,58 @@
+using UnityEngine;
+
+namespace Ludo.Scenes.Flow
+{
+    /// <summary>
+    /// Generic finite state machine that operates on <see cref="FlowState{TEvent}"/> states.
+    /// </summary>
+    /// <typeparam name="TEvent">Type of events driving transitions.</typeparam>
+    public class StateMachine<TEvent> where TEvent : struct
+    {
+        FlowState<TEvent>? _current;
+        Awaitable _transition; // ensures sequential transitions
+
+        /// <summary>
+        /// The currently active state.
+        /// </summary>
+        public FlowState<TEvent>? Current => _current;
+
+        /// <summary>
+        /// Enters the provided state as the first state of the machine.
+        /// </summary>
+        public async Awaitable SetInitialState(FlowState<TEvent> state)
+        {
+            _current = state;
+            await _current.Enter();
+        }
+
+        /// <summary>
+        /// Sends an event to the current state and performs transitions if requested.
+        /// </summary>
+        public Awaitable Dispatch(TEvent evt)
+        {
+            var pending = _transition;
+            return _transition = Run();
+
+            async Awaitable Run()
+            {
+                await pending; // wait for any transition already in progress
+                if (_current == null)
+                    return;
+
+                var next = _current.Handle(evt);
+                if (next != null && next != _current)
+                {
+                    await _current.Exit();
+                    _current = next;
+                    await _current.Enter();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Updates the active state. Should be called once per frame.
+        /// </summary>
+        public void Tick() => _current?.Tick();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `FlowState`, `StateMachine`, and `SceneFlowController` to orchestrate deterministic scene flows
- support nested sub-flows and strongly typed event-driven transitions
- remove `.meta` files so Unity can generate them automatically

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a872b98cd083229b2d0f89d2ebc36b