### PR TITLE
Implement main menu scene flow

### DIFF
--- a/Assets/Game/Scripts/MainMenu/MainMenuFlowController.cs
+++ b/Assets/Game/Scripts/MainMenu/MainMenuFlowController.cs
@@ -1,0 +1,148 @@
+using Ludo.Core;
+using Ludo.Scenes;
+using Ludo.Scenes.Flow;
+using UnityEngine;
+
+namespace Game.MainMenu
+{
+    public enum MainMenuEvent
+    {
+        StartGame,
+        ShowCredits,
+        ShowSettings,
+        Back
+    }
+
+    /// <summary>
+    /// Orchestrates the flow of the main menu using Ludo's scene flow framework.
+    /// </summary>
+    public class MainMenuFlowController : SceneFlowController<MainMenuEvent>
+    {
+        [Header("Pages")]
+        [SerializeField] private GameObject mainPage;
+        [SerializeField] private GameObject creditsPage;
+        [SerializeField] private GameObject settingsPage;
+
+        protected override FlowState<MainMenuEvent> CreateInitialState()
+        {
+            return new HomeState(this, mainPage, creditsPage, settingsPage);
+        }
+
+        // Methods exposed for UI buttons
+        public void StartNewGame() => Machine.Dispatch(MainMenuEvent.StartGame);
+        public void ShowCredits() => Machine.Dispatch(MainMenuEvent.ShowCredits);
+        public void ShowSettings() => Machine.Dispatch(MainMenuEvent.ShowSettings);
+        public void Back() => Machine.Dispatch(MainMenuEvent.Back);
+    }
+
+    /// <summary>
+    /// Default state showing the primary menu options.
+    /// </summary>
+    sealed class HomeState : FlowState<MainMenuEvent>
+    {
+        readonly GameObject _main;
+        readonly GameObject _credits;
+        readonly GameObject _settings;
+
+        public HomeState(MainMenuFlowController controller, GameObject main, GameObject credits, GameObject settings)
+            : base(controller)
+        {
+            _main = main;
+            _credits = credits;
+            _settings = settings;
+        }
+
+        public override Awaitable Enter()
+        {
+            _main?.SetActive(true);
+            _credits?.SetActive(false);
+            _settings?.SetActive(false);
+            return default;
+        }
+
+        public override FlowState<MainMenuEvent>? Handle(MainMenuEvent evt)
+        {
+            switch (evt)
+            {
+                case MainMenuEvent.StartGame:
+                {
+                    var sceneService = ServiceLocator.Get<ISceneService>();
+                    sceneService.Load("Game");
+                    return this;
+                }
+                case MainMenuEvent.ShowCredits:
+                    return new CreditsState((MainMenuFlowController)Controller, _main, _credits, _settings);
+                case MainMenuEvent.ShowSettings:
+                    return new SettingsState((MainMenuFlowController)Controller, _main, _credits, _settings);
+            }
+
+            return this;
+        }
+    }
+
+    /// <summary>
+    /// State representing the credits sub page.
+    /// </summary>
+    sealed class CreditsState : FlowState<MainMenuEvent>
+    {
+        readonly GameObject _main;
+        readonly GameObject _credits;
+        readonly GameObject _settings;
+
+        public CreditsState(MainMenuFlowController controller, GameObject main, GameObject credits, GameObject settings)
+            : base(controller)
+        {
+            _main = main;
+            _credits = credits;
+            _settings = settings;
+        }
+
+        public override Awaitable Enter()
+        {
+            _main?.SetActive(false);
+            _credits?.SetActive(true);
+            _settings?.SetActive(false);
+            return default;
+        }
+
+        public override FlowState<MainMenuEvent>? Handle(MainMenuEvent evt)
+        {
+            if (evt == MainMenuEvent.Back)
+                return new HomeState((MainMenuFlowController)Controller, _main, _credits, _settings);
+            return this;
+        }
+    }
+
+    /// <summary>
+    /// State representing the settings sub page.
+    /// </summary>
+    sealed class SettingsState : FlowState<MainMenuEvent>
+    {
+        readonly GameObject _main;
+        readonly GameObject _credits;
+        readonly GameObject _settings;
+
+        public SettingsState(MainMenuFlowController controller, GameObject main, GameObject credits, GameObject settings)
+            : base(controller)
+        {
+            _main = main;
+            _credits = credits;
+            _settings = settings;
+        }
+
+        public override Awaitable Enter()
+        {
+            _main?.SetActive(false);
+            _credits?.SetActive(false);
+            _settings?.SetActive(true);
+            return default;
+        }
+
+        public override FlowState<MainMenuEvent>? Handle(MainMenuEvent evt)
+        {
+            if (evt == MainMenuEvent.Back)
+                return new HomeState((MainMenuFlowController)Controller, _main, _credits, _settings);
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `MainMenuFlowController` leveraging Ludo Scene Flow
- handle start game, credits, and settings transitions with separate states
- remove Unity-generated `.meta` files to rely on auto-generation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a87f5a7ff0832296abc0dc9232284c