### PR TITLE
Add input service using Unity's InputSystem

### DIFF
--- a/Assets/Game/Scripts/Core/AppRoot.cs
+++ b/Assets/Game/Scripts/Core/AppRoot.cs
@@ -6,6 +6,7 @@ using Ludo.Pools.Runtime;
 using Ludo.Scenes;
 using UnityEngine;
 using Ludo.Core.Boot;
+using Ludo.Core.Services;
 
 namespace Game.Core
 {
@@ -52,6 +53,8 @@ namespace Game.Core
             ServiceLocator.Register<ISceneService>(new SceneService());
 
             ServiceLocator.Register<IPoolService>(new PoolService());
+
+            ServiceLocator.Register<IInputService>(new InputService());
         }
 
         /// <summary>
@@ -70,6 +73,10 @@ namespace Game.Core
             var poolService = ServiceLocator.Get<IPoolService>();
             poolService?.Clear();
             ServiceLocator.Unregister<IPoolService>();
+
+            var inputService = ServiceLocator.Get<IInputService>();
+            inputService?.Dispose();
+            ServiceLocator.Unregister<IInputService>();
         }
 
     }

--- a/Assets/Ludo/Core/Runtime/Services/IInputService.cs
+++ b/Assets/Ludo/Core/Runtime/Services/IInputService.cs
@@ -1,7 +1,15 @@
-namespace Ludo.Scenes
+using System;
+using UnityEngine;
+
+namespace Ludo.Core.Services
 {
-    public interface IInputService
+    public interface IInputService : IDisposable
     {
-        
+        event Action<Vector2> Move;
+        event Action<Vector2> Look;
+        event Action Attack;
+
+        void EnablePlayer();
+        void DisablePlayer();
     }
 }

--- a/Assets/Ludo/Core/Runtime/Services/InputService.cs
+++ b/Assets/Ludo/Core/Runtime/Services/InputService.cs
@@ -1,0 +1,56 @@
+using System;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+namespace Ludo.Core.Services
+{
+    public sealed class InputService : IInputService
+    {
+        readonly InputSystem_Actions _actions;
+        readonly Action<InputAction.CallbackContext> _movePerformed;
+        readonly Action<InputAction.CallbackContext> _moveCanceled;
+        readonly Action<InputAction.CallbackContext> _lookPerformed;
+        readonly Action<InputAction.CallbackContext> _lookCanceled;
+        readonly Action<InputAction.CallbackContext> _attackPerformed;
+
+        public event Action<Vector2> Move;
+        public event Action<Vector2> Look;
+        public event Action Attack;
+
+        public InputService()
+        {
+            _actions = new InputSystem_Actions();
+
+            _movePerformed = ctx => Move?.Invoke(ctx.ReadValue<Vector2>());
+            _moveCanceled = ctx => Move?.Invoke(Vector2.zero);
+            _lookPerformed = ctx => Look?.Invoke(ctx.ReadValue<Vector2>());
+            _lookCanceled = ctx => Look?.Invoke(Vector2.zero);
+            _attackPerformed = _ => Attack?.Invoke();
+
+            Bind();
+            _actions.Player.Enable();
+        }
+
+        void Bind()
+        {
+            _actions.Player.Move.performed += _movePerformed;
+            _actions.Player.Move.canceled += _moveCanceled;
+            _actions.Player.Look.performed += _lookPerformed;
+            _actions.Player.Look.canceled += _lookCanceled;
+            _actions.Player.Attack.performed += _attackPerformed;
+        }
+
+        public void EnablePlayer() => _actions.Player.Enable();
+        public void DisablePlayer() => _actions.Player.Disable();
+
+        public void Dispose()
+        {
+            _actions.Player.Move.performed -= _movePerformed;
+            _actions.Player.Move.canceled -= _moveCanceled;
+            _actions.Player.Look.performed -= _lookPerformed;
+            _actions.Player.Look.canceled -= _lookCanceled;
+            _actions.Player.Attack.performed -= _attackPerformed;
+            _actions.Dispose();
+        }
+    }
+}

--- a/Assets/Ludo/Core/Runtime/Services/InputService.cs.meta
+++ b/Assets/Ludo/Core/Runtime/Services/InputService.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1fea43f9d6e646bcbf47943df78f1db8
+timeCreated: 1755888122


### PR DESCRIPTION
## Summary
- define IInputService with move/look/attack events and action-map control
- implement InputService wrapping generated InputSystem actions
- register and teardown InputService in AppRoot

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b9754a0c83228b91b0c75f33b965